### PR TITLE
feat(android): use new map api

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 
 dependencies {
-	implementation 'com.google.android.gms:play-services-maps:18.0.0'
+	implementation 'com.google.android.gms:play-services-maps:18.0.2'
 	implementation 'com.google.maps.android:android-maps-utils:2.3.0'
 	implementation 'androidx.fragment:fragment:1.3.6'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 
 dependencies {
-	implementation 'com.google.android.gms:play-services-maps:17.0.1'
+	implementation 'com.google.android.gms:play-services-maps:18.0.0'
 	implementation 'com.google.maps.android:android-maps-utils:2.2.5'
 	implementation 'androidx.fragment:fragment:1.3.6'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 
 dependencies {
 	implementation 'com.google.android.gms:play-services-maps:18.0.0'
-	implementation 'com.google.maps.android:android-maps-utils:2.2.5'
+	implementation 'com.google.maps.android:android-maps-utils:2.3.0'
 	implementation 'androidx.fragment:fragment:1.3.6'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.3.3
+version: 5.4.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: External version of Map module using native Google Maps library

--- a/android/src/ti/map/MapModule.java
+++ b/android/src/ti/map/MapModule.java
@@ -167,7 +167,8 @@ public class MapModule extends KrollModule implements OnMapsSdkInitializedCallba
 	}
 
 	@Override
-	public void onMapsSdkInitialized(@NonNull MapsInitializer.Renderer renderer) {
+	public void onMapsSdkInitialized(@NonNull MapsInitializer.Renderer renderer)
+	{
 		switch (renderer) {
 			case LATEST:
 				Log.d("MapsDemo", "The latest version of the renderer is used.");

--- a/android/src/ti/map/MapModule.java
+++ b/android/src/ti/map/MapModule.java
@@ -8,17 +8,18 @@
  */
 package ti.map;
 
+import androidx.annotation.NonNull;
+
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.MapsInitializer;
+import com.google.android.gms.maps.OnMapsSdkInitializedCallback;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
+
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.annotations.Kroll;
-import org.appcelerator.titanium.TiApplication;
-import com.google.android.gms.maps.MapsInitializer;
-import com.google.android.gms.maps.OnMapsSdkInitializedCallback;
-import androidx.annotation.NonNull;
 import org.appcelerator.kroll.common.Log;
+import org.appcelerator.titanium.TiApplication;
 
 
 @Kroll.module(name = "Map", id = "ti.map")

--- a/android/src/ti/map/MapModule.java
+++ b/android/src/ti/map/MapModule.java
@@ -21,7 +21,6 @@ import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiApplication;
 
-
 @Kroll.module(name = "Map", id = "ti.map")
 public class MapModule extends KrollModule implements OnMapsSdkInitializedCallback
 {

--- a/android/src/ti/map/MapModule.java
+++ b/android/src/ti/map/MapModule.java
@@ -171,11 +171,8 @@ public class MapModule extends KrollModule implements OnMapsSdkInitializedCallba
 	public void onMapsSdkInitialized(@NonNull MapsInitializer.Renderer renderer)
 	{
 		switch (renderer) {
-			case LATEST:
-				Log.d("MapsDemo", "The latest version of the renderer is used.");
-				break;
 			case LEGACY:
-				Log.d("MapsDemo", "The legacy version of the renderer is used.");
+				Log.d("Ti.Map", "The legacy version of the renderer is used.");
 				break;
 		}
 	}

--- a/android/src/ti/map/MapModule.java
+++ b/android/src/ti/map/MapModule.java
@@ -15,9 +15,14 @@ import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiApplication;
+import com.google.android.gms.maps.MapsInitializer;
+import com.google.android.gms.maps.OnMapsSdkInitializedCallback;
+import androidx.annotation.NonNull;
+import org.appcelerator.kroll.common.Log;
+
 
 @Kroll.module(name = "Map", id = "ti.map")
-public class MapModule extends KrollModule
+public class MapModule extends KrollModule implements OnMapsSdkInitializedCallback
 {
 	public static final String EVENT_MAP_CLICK = "mapclick";
 	public static final String EVENT_PIN_CHANGE_DRAG_STATE = "pinchangedragstate";
@@ -146,7 +151,7 @@ public class MapModule extends KrollModule
 	public MapModule()
 	{
 		super();
-		MapsInitializer.initialize(TiApplication.getInstance().getApplicationContext());
+		MapsInitializer.initialize(TiApplication.getInstance().getApplicationContext(), MapsInitializer.Renderer.LATEST, this);
 	}
 
 	@Kroll.method
@@ -159,5 +164,17 @@ public class MapModule extends KrollModule
 	public String getApiName()
 	{
 		return "Ti.Map";
+	}
+
+	@Override
+	public void onMapsSdkInitialized(@NonNull MapsInitializer.Renderer renderer) {
+		switch (renderer) {
+			case LATEST:
+				Log.d("MapsDemo", "The latest version of the renderer is used.");
+				break;
+			case LEGACY:
+				Log.d("MapsDemo", "The legacy version of the renderer is used.");
+				break;
+		}
 	}
 }

--- a/android/src/ti/map/MapModule.java
+++ b/android/src/ti/map/MapModule.java
@@ -9,13 +9,11 @@
 package ti.map;
 
 import androidx.annotation.NonNull;
-
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.MapsInitializer;
 import com.google.android.gms.maps.OnMapsSdkInitializedCallback;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
-
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
@@ -151,7 +149,8 @@ public class MapModule extends KrollModule implements OnMapsSdkInitializedCallba
 	public MapModule()
 	{
 		super();
-		MapsInitializer.initialize(TiApplication.getInstance().getApplicationContext(), MapsInitializer.Renderer.LATEST, this);
+		MapsInitializer.initialize(TiApplication.getInstance().getApplicationContext(), MapsInitializer.Renderer.LATEST,
+								   this);
 	}
 
 	@Kroll.method


### PR DESCRIPTION
* Use new Map Renderer (https://developers.google.com/maps/documentation/android-sdk/renderer)
* updated map-utils

> An upgraded map renderer is available as of version 18.0.0 of the Maps SDK for Android. This renderer brings many improvements, including support for Cloud-based maps styling. You can opt-in to try the new renderer before it becomes the default renderer for Android devices, through a progressive rollout starting in March 2022 at the earliest.

[ti.map-android-5.4.0.zip](https://github.com/appcelerator-modules/ti.map/files/8108987/ti.map-android-5.4.0.zip)



there are a lot of debug messages ` ProxyAndroidLoggerBackend: Too many Flogger logs received before configuration. Dropping old logs.`
