### PR TITLE
feat(android): version update

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,11 @@
 
 dependencies {
+	// https://developers.google.com/android/guides/releases
 	implementation 'com.google.android.gms:play-services-maps:18.1.0'
+
+	// https://github.com/googlemaps/android-maps-utils/releases
 	implementation 'com.google.maps.android:android-maps-utils:2.4.0'
-	implementation 'androidx.fragment:fragment:1.4.1'
+
+	// https://developer.android.com/jetpack/androidx/releases/fragment
+	implementation 'androidx.fragment:fragment:1.5.2'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 
 dependencies {
-	implementation 'com.google.android.gms:play-services-maps:18.0.2'
-	implementation 'com.google.maps.android:android-maps-utils:2.3.0'
-	implementation 'androidx.fragment:fragment:1.3.6'
+	implementation 'com.google.android.gms:play-services-maps:18.1.0'
+	implementation 'com.google.maps.android:android-maps-utils:2.4.0'
+	implementation 'androidx.fragment:fragment:1.4.1'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.4.0
+version: 5.5.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: External version of Map module using native Google Maps library


### PR DESCRIPTION
just some house keeping:

* update maps to 18.1.0. No big changes but they have some new styling options for Shapes we could implement (https://developers.google.com/maps/documentation/android-sdk/shapes#polyline-customization). Sadly they still log so much stuff :disappointed: 
* match android fragment version with the version that is in the SDK
* update map utils to 2.4.0 (also no big changes, https://github.com/googlemaps/android-maps-utils/releases/tag/v2.4.0)


[ti.map-android-5.5.0.zip](https://github.com/tidev/ti.map/files/9616509/ti.map-android-5.5.0.zip)

