### PR TITLE
fix: guard invalid blob creation

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.5.0
+version: 5.5.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: External version of Map module using native Google Maps library

--- a/android/src/ti/map/AnnotationProxy.java
+++ b/android/src/ti/map/AnnotationProxy.java
@@ -324,6 +324,7 @@ public class AnnotationProxy extends KrollProxy
 					markerOptions.icon(BitmapDescriptorFactory.fromBitmap(bitmap));
 					setIconImageDimensions(bitmap.getWidth(), bitmap.getHeight());
 				} catch (Exception e) {
+					Log.e(TAG, e.getMessage());
 				}
 				return;
 			}
@@ -333,8 +334,12 @@ public class AnnotationProxy extends KrollProxy
 		if (image instanceof TiBlob) {
 			Bitmap bitmap = ((TiBlob) image).getImage();
 			if (bitmap != null) {
-				markerOptions.icon(BitmapDescriptorFactory.fromBitmap(bitmap));
-				setIconImageDimensions(bitmap.getWidth(), bitmap.getHeight());
+				try {
+					markerOptions.icon(BitmapDescriptorFactory.fromBitmap(bitmap));
+					setIconImageDimensions(bitmap.getWidth(), bitmap.getHeight());
+				} catch (Exception e) {
+					Log.e(TAG, e.getMessage());
+				}
 				return;
 			}
 		}


### PR DESCRIPTION
Caused by missing memory (which can happen). The error is `Uncaught Error: Could not copy bitmap to parcel blob.`

Beta: [ti.map-android-5.5.1.zip](https://github.com/tidev/ti.map/files/10232111/ti.map-android-5.5.1.zip)

```
       at android.graphics.Bitmap.nativeWriteToParcel(Native Method)
       at android.graphics.Bitmap.writeToParcel(Bitmap.java:2140)
       at com.google.android.gms.internal.maps.zzc.zze(com.google.android.gms:play-services-maps@@18.1.0:3)
       at com.google.android.gms.internal.maps.zzg.zzg(com.google.android.gms:play-services-maps@@18.1.0:2)
       at com.google.android.gms.maps.model.BitmapDescriptorFactory.fromBitmap(com.google.android.gms:play-services-maps@@18.1.0:2)
       at ti.map.AnnotationProxy.handleImage(AnnotationProxy.java:324)
       at ti.map.AnnotationProxy.processOptions(AnnotationProxy.java:270)
       at ti.map.TiUIMapView.addAnnotation(TiUIMapView.java:634)
       at ti.map.ViewProxy.handleAddAnnotation(ViewProxy.java:372)
       at ti.map.ViewProxy.handleAddAnnotations(ViewProxy.java:415)
```