### PR TITLE
feat(android): update libraries, add "zIndex" getter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,8 +4,8 @@ dependencies {
 	implementation 'com.google.android.gms:play-services-maps:18.1.0'
 
 	// https://github.com/googlemaps/android-maps-utils/releases
-	implementation 'com.google.maps.android:android-maps-utils:2.4.0'
+	implementation 'com.google.maps.android:android-maps-utils:3.4.0'
 
 	// https://developer.android.com/jetpack/androidx/releases/fragment
-	implementation 'androidx.fragment:fragment:1.5.2'
+	implementation 'androidx.fragment:fragment:1.5.5'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 	implementation 'com.google.android.gms:play-services-maps:18.1.0'
 
 	// https://github.com/googlemaps/android-maps-utils/releases
-	implementation 'com.google.maps.android:android-maps-utils:3.4.0'
+	implementation 'com.google.maps.android:android-maps-utils:3.5.3'
 
 	// https://developer.android.com/jetpack/androidx/releases/fragment
 	implementation 'androidx.fragment:fragment:1.5.5'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 	implementation 'com.google.maps.android:android-maps-utils:3.5.3'
 
 	// https://developer.android.com/jetpack/androidx/releases/fragment
-	implementation 'androidx.fragment:fragment:1.5.5'
+	implementation 'androidx.fragment:fragment:1.5.7'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.5.1
+version: 5.5.2
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: External version of Map module using native Google Maps library

--- a/android/src/ti/map/TiMarker.java
+++ b/android/src/ti/map/TiMarker.java
@@ -74,4 +74,13 @@ public class TiMarker implements ClusterItem
 		}
 		return null;
 	}
+
+	@Override
+	public Float getZIndex()
+	{
+		if (proxy != null) {
+			return proxy.getMarkerOptions().getZIndex();
+		}
+		return null;
+	}
 }


### PR DESCRIPTION
* update map-utils (https://github.com/googlemaps/android-maps-utils/releases)
* added `getZIndex` to make it build with the new version (was added in map-utils 3.2.0)
* match androidx.fragment:fragment version with SDK version


**Null check update**
My PR into the Google map-utils repo ("null check") was accepted and merged by google :+1:  ! 
That should reduce some random "null errors" in the internal `onAnimationUpdate` function.


----

**Side note:**


`getColor` can be overwritten in TiCluserRenderer now to set custom colors like
```java
    @Override
    public int getColor(int clusterSize) {
        final float hueRange = 220;
        final float sizeRange = 300;
        final float size = Math.min(clusterSize, sizeRange);
        final float hue = (sizeRange - size) * (sizeRange - size) / (sizeRange * sizeRange) * hueRange;
        return Color.HSVToColor(new float[]{
                hue, 1f, .6f
        });
    }
```

but not part of this PR :)