### PR TITLE
fix(android): use activity in toColor

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.5.1
+version: 5.5.2
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: External version of Map module using native Google Maps library

--- a/android/src/ti/map/CircleProxy.java
+++ b/android/src/ti/map/CircleProxy.java
@@ -6,6 +6,7 @@
  */
 package ti.map;
 
+import android.app.Activity;
 import android.graphics.Color;
 import android.os.Message;
 import android.view.ViewGroup;
@@ -146,6 +147,7 @@ public class CircleProxy extends KrollProxy implements IShape
 	public void processOptions()
 	{
 		options = new CircleOptions();
+		Activity currentActivity = TiApplication.getAppCurrentActivity();
 
 		if (hasProperty(MapModule.PROPERTY_CENTER)) {
 			options.center(TiMapUtils.parseLocation(getProperty(MapModule.PROPERTY_CENTER)));
@@ -160,11 +162,13 @@ public class CircleProxy extends KrollProxy implements IShape
 		}
 
 		if (hasProperty(MapModule.PROPERTY_STROKE_COLOR)) {
-			options.strokeColor(alphaColor(TiConvert.toColor((String) getProperty(MapModule.PROPERTY_STROKE_COLOR))));
+			options.strokeColor(
+				alphaColor(TiConvert.toColor((String) getProperty(MapModule.PROPERTY_STROKE_COLOR), currentActivity)));
 		}
 
 		if (hasProperty(MapModule.PROPERTY_FILL_COLOR)) {
-			options.fillColor(alphaColor(TiConvert.toColor((String) getProperty(MapModule.PROPERTY_FILL_COLOR))));
+			options.fillColor(
+				alphaColor(TiConvert.toColor((String) getProperty(MapModule.PROPERTY_FILL_COLOR), currentActivity)));
 		}
 
 		if (hasProperty(MapModule.PROPERTY_ZINDEX)) {
@@ -184,6 +188,7 @@ public class CircleProxy extends KrollProxy implements IShape
 	public void onPropertyChanged(String name, Object value)
 	{
 		super.onPropertyChanged(name, value);
+		Activity currentActivity = TiApplication.getAppCurrentActivity();
 		if (circle == null) {
 			return;
 		}
@@ -203,12 +208,12 @@ public class CircleProxy extends KrollProxy implements IShape
 
 		else if (name.equals(MapModule.PROPERTY_STROKE_COLOR)) {
 			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_SET_STROKE_COLOR),
-												TiConvert.toColor((String) value));
+												TiConvert.toColor((String) value, currentActivity));
 		}
 
 		else if (name.equals(MapModule.PROPERTY_FILL_COLOR)) {
 			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_SET_FILL_COLOR),
-												TiConvert.toColor((String) value));
+												TiConvert.toColor((String) value, currentActivity));
 		}
 
 		else if (name.equals(MapModule.PROPERTY_ZINDEX)) {

--- a/android/src/ti/map/PolygonProxy.java
+++ b/android/src/ti/map/PolygonProxy.java
@@ -6,6 +6,7 @@
  */
 package ti.map;
 
+import android.app.Activity;
 import android.os.Message;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Polygon;
@@ -18,6 +19,7 @@ import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.AsyncResult;
 import org.appcelerator.kroll.common.TiMessenger;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.util.TiConvert;
 import ti.map.Shape.IShape;
@@ -109,7 +111,7 @@ public class PolygonProxy extends KrollProxy implements IShape
 	{
 
 		options = new PolygonOptions();
-
+		Activity currentActivity = TiApplication.getAppCurrentActivity();
 		if (hasProperty(MapModule.PROPERTY_POINTS)) {
 			processPoints(getProperty(MapModule.PROPERTY_POINTS), false);
 		}
@@ -119,7 +121,8 @@ public class PolygonProxy extends KrollProxy implements IShape
 		}
 
 		if (hasProperty(MapModule.PROPERTY_STROKE_COLOR)) {
-			options.strokeColor(TiConvert.toColor((String) getProperty(MapModule.PROPERTY_STROKE_COLOR)));
+			options.strokeColor(
+				TiConvert.toColor((String) getProperty(MapModule.PROPERTY_STROKE_COLOR), currentActivity));
 		}
 
 		if (hasProperty(MapModule.PROPERTY_STROKE_WIDTH)) {
@@ -127,7 +130,7 @@ public class PolygonProxy extends KrollProxy implements IShape
 		}
 
 		if (hasProperty(MapModule.PROPERTY_FILL_COLOR)) {
-			options.fillColor(TiConvert.toColor((String) getProperty(MapModule.PROPERTY_FILL_COLOR)));
+			options.fillColor(TiConvert.toColor((String) getProperty(MapModule.PROPERTY_FILL_COLOR), currentActivity));
 		}
 
 		if (hasProperty(MapModule.PROPERTY_ZINDEX)) {
@@ -266,7 +269,7 @@ public class PolygonProxy extends KrollProxy implements IShape
 	{
 
 		super.onPropertyChanged(name, value);
-
+		Activity currentActivity = TiApplication.getAppCurrentActivity();
 		if (polygon == null) {
 			return;
 		}
@@ -282,12 +285,12 @@ public class PolygonProxy extends KrollProxy implements IShape
 
 		else if (name.equals(MapModule.PROPERTY_STROKE_COLOR)) {
 			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_SET_STROKE_COLOR),
-												TiConvert.toColor((String) value));
+												TiConvert.toColor((String) value, currentActivity));
 		}
 
 		else if (name.equals(MapModule.PROPERTY_FILL_COLOR)) {
 			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_SET_FILL_COLOR),
-												TiConvert.toColor((String) value));
+												TiConvert.toColor((String) value, currentActivity));
 		}
 
 		else if (name.equals(MapModule.PROPERTY_ZINDEX)) {

--- a/android/src/ti/map/PolylineProxy.java
+++ b/android/src/ti/map/PolylineProxy.java
@@ -6,6 +6,7 @@
  */
 package ti.map;
 
+import android.app.Activity;
 import android.os.Message;
 import com.google.android.gms.maps.model.Dash;
 import com.google.android.gms.maps.model.Dot;
@@ -24,6 +25,7 @@ import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.AsyncResult;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.kroll.common.TiMessenger;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.util.TiConvert;
 import ti.map.Shape.IShape;
@@ -134,6 +136,7 @@ public class PolylineProxy extends KrollProxy implements IShape
 	{
 
 		options = new PolylineOptions();
+		Activity currentActivity = TiApplication.getAppCurrentActivity();
 		// (int) strokeColor
 		// (float) strokeWidth
 		// (int) fillColor
@@ -144,12 +147,13 @@ public class PolylineProxy extends KrollProxy implements IShape
 		}
 
 		if (hasProperty(MapModule.PROPERTY_STROKE_COLOR)) {
-			options.color(TiConvert.toColor((String) getProperty(MapModule.PROPERTY_STROKE_COLOR)));
+			options.color(TiConvert.toColor((String) getProperty(MapModule.PROPERTY_STROKE_COLOR), currentActivity));
 		}
 
 		// alternate API
 		if (hasProperty(PolylineProxy.PROPERTY_STROKE_COLOR2)) {
-			options.color(TiConvert.toColor((String) getProperty(PolylineProxy.PROPERTY_STROKE_COLOR2)));
+			options.color(
+				TiConvert.toColor((String) getProperty(PolylineProxy.PROPERTY_STROKE_COLOR2), currentActivity));
 		}
 
 		if (hasProperty(MapModule.PROPERTY_STROKE_WIDTH)) {
@@ -243,7 +247,7 @@ public class PolylineProxy extends KrollProxy implements IShape
 	{
 
 		super.onPropertyChanged(name, value);
-
+		Activity currentActivity = TiApplication.getAppCurrentActivity();
 		if (polyline == null) {
 			return;
 		}
@@ -264,12 +268,12 @@ public class PolylineProxy extends KrollProxy implements IShape
 
 		else if (name.equals(MapModule.PROPERTY_STROKE_COLOR)) {
 			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_SET_STROKE_COLOR),
-												TiConvert.toColor((String) value));
+												TiConvert.toColor((String) value, currentActivity));
 		}
 		// alternate API
 		else if (name.equals(PolylineProxy.PROPERTY_STROKE_COLOR2)) {
 			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_SET_STROKE_COLOR),
-												TiConvert.toColor((String) value));
+												TiConvert.toColor((String) value, currentActivity));
 		}
 
 		else if (name.equals(PolylineProxy.PROPERTY_ZINDEX)) {

--- a/android/src/ti/map/RouteProxy.java
+++ b/android/src/ti/map/RouteProxy.java
@@ -18,6 +18,7 @@ import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.AsyncResult;
 import org.appcelerator.kroll.common.TiMessenger;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.util.TiConvert;
 
@@ -86,7 +87,8 @@ public class RouteProxy extends KrollProxy
 		}
 
 		if (hasProperty(TiC.PROPERTY_COLOR)) {
-			options.color(TiConvert.toColor((String) getProperty(TiC.PROPERTY_COLOR)));
+			options.color(
+				TiConvert.toColor((String) getProperty(TiC.PROPERTY_COLOR), TiApplication.getAppCurrentActivity()));
 		}
 	}
 
@@ -160,8 +162,9 @@ public class RouteProxy extends KrollProxy
 		}
 
 		else if (name.equals(TiC.PROPERTY_COLOR)) {
-			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_SET_COLOR),
-												TiConvert.toColor((String) value));
+			TiMessenger.sendBlockingMainMessage(
+				getMainHandler().obtainMessage(MSG_SET_COLOR),
+				TiConvert.toColor((String) value, TiApplication.getAppCurrentActivity()));
 		}
 
 		else if (name.equals(TiC.PROPERTY_WIDTH)) {


### PR DESCRIPTION
use non deprecated "toColor(string, activity)" for https://github.com/tidev/titanium_mobile/pull/13273

[ti.map-android-5.5.2.zip](https://github.com/tidev/ti.map/files/11463940/ti.map-android-5.5.2.zip)
