### PR TITLE
feat(ios): add new search completion APIs

### DIFF
--- a/apidoc/Map.yml
+++ b/apidoc/Map.yml
@@ -42,13 +42,14 @@ description: |
         </ti:app>
         ```
 
-    -   Instantiate the module with the `require('ti.map')` method, then make subsequent API calls with
+    -   Instantiate the module with the `import Map from 'ti.map'` API, then make subsequent API calls with
         the new map object.
 
         ``` javascript
-        var Map = require('ti.map');
-        var mapview = Map.createView({ 
-          mapType: Map.NORMAL_TYPE 
+        import Map from 'ti.map';
+
+        const mapView = Map.createView({
+          mapType: Map.NORMAL_TYPE
         });
         ```
 
@@ -99,12 +100,13 @@ description: |
         </ti:app>
         ```
 
-    -   Instantiate the module with the `require('ti.map')` method, then make subsequent API calls with
+    -   Instantiate the module with the `import Map from 'ti.map'` API, then make subsequent API calls with
         the new map object.
 
         ``` javascript
-        var Map = require('ti.map');
-        var mapview = Map.createView({
+        import Map from 'ti.map';
+
+        const mapView = Map.createView({
           mapType: Map.NORMAL_TYPE
         });
         ```
@@ -495,6 +497,43 @@ methods:
     summary: Returns a code to indicate whether Google Play Services is available on the device.
     since: "3.1.1"
     platforms: [android]
+  
+  - name: search
+    summary: |
+        Uses the native `MKLocalSearchCompleter` class to search places for
+        a given input value.
+    description: |
+        Please use the `didUpdateResults` event to get updates for a search
+        completion request via the `results` field. If the search failed, the
+        `results` field is empty and an `error` is provided.
+    parameters:
+      - name: value
+        summary: The value to search with.
+        type: String
+      - name: options
+        summary: Additional options to fine-tune the search request.
+        type: SearchCompletionOptions
+    platforms: [iphone, ipad, macos]
+    since: "12.3.0"
+
+  - name: geocodeAddress
+    summary: |
+        Resolve address details using the `CLGeocoder` to get information (e.g.
+        latitude, longitude, postal code and city) about a given input address.
+    description: |
+        The result is provided via the callback (second function argument).
+    parameters:
+      - name: address
+        summary: The address to resolve.
+        type: String
+      - name: callback
+        summary: |
+            Function to be called upon completion (either success with a place
+            or an error).
+        type: Callback<Object>
+        optional: false
+    platforms: [iphone, ipad, macos]
+    since: "12.3.0"
 
   - name: getLookAroundImage
     summary:  A utility function that you use to create a static image from a LookAround scene.
@@ -539,10 +578,11 @@ examples:
         and it is not practical to identify them by title.
 
         ``` javascript
-        var Map = require('ti.map');
-        var win = Titanium.UI.createWindow();
+        import Map from 'ti.map';
 
-        var mountainView = Map.createAnnotation({
+        const window = Ti.UI.createWindow();
+
+        const mountainView = Map.createAnnotation({
             latitude: 37.390749,
             longitude: -122.081651,
             title: 'Appcelerator Headquarters',
@@ -551,7 +591,7 @@ examples:
             myid: 1 // Custom property to uniquely identify this annotation.
         });
 
-        var mapview = Map.createView({
+        const mapView = Map.createView({
             mapType: Map.NORMAL_TYPE,
             region: { 
                 latitude: 33.74511,
@@ -565,7 +605,7 @@ examples:
             annotations: [ mountainView ]
         });
 
-        var circle = Map.createCircle({
+        const circle = Map.createCircle({
             center: {
                 latitude: 33.74511,
                 longitude: -84.38993
@@ -573,14 +613,15 @@ examples:
             radius: 1000, // = 1.0 km
             fillColor: '#20FF0000'
         });
-        mapview.addCircle(circle);
 
-        win.add(mapview);
+        mapView.addCircle(circle);
+        window.add(mapView);
 
-        mapview.addEventListener('click', function(event) {
+        mapView.addEventListener('click', event => {
             Ti.API.info('Clicked ' + event.clicksource + ' on ' + event.latitude + ', ' + event.longitude);
         });
-        win.open();
+
+        windown.open();
         ```
   - title: Alloy XML Markup
     example: |
@@ -605,7 +646,7 @@ examples:
         ``` xml
         <Alloy>
             <Window>
-                <Module id="mapview" module="ti.map" onClick="report" method="createView">
+                <Module id="mapView" module="ti.map" onClick="report" method="createView">
                     <Annotation id="appcHQ" myId="1337" />
                 </Module>
             </Window>
@@ -615,7 +656,7 @@ examples:
         `app/styles/index.tss`:
 
         ``` javascript
-        "#mapview": {
+        "#mapView": {
             region: {
                 latitude: 33.74511,
                 longitude: -84.38993,
@@ -651,11 +692,12 @@ examples:
         view instance.
 
         ``` javascript
-        var Map = require('ti.map');
-        var win = Titanium.UI.createWindow();
-        var annotations = [];
+        import Map from 'ti.map';
 
-        for (var i = 0; i < 10; i++) {
+        const window = Ti.UI.createWindow();
+        const annotations = [];
+
+        for (let i = 0; i < 10; i++) {
             annotations.push(Map.createAnnotation({
                 title: 'Appcelerator Inc.',
                 subtitle: 'TiRocks!',
@@ -675,7 +717,7 @@ examples:
             }));
         }
 
-        var mapview = Map.createView({
+        const mapView = Map.createView({
             annotations: annotations,
             rotateEnabled: true,
             mapType: Map.MUTED_STANDARD_TYPE,
@@ -683,23 +725,37 @@ examples:
             userLocation: true
         });
 
-        mapview.addEventListener('clusterstart', function(e) {
+        mapView.addEventListener('clusterstart', event => {
             Ti.API.info('clustering started!');
 
-            var clusterAnnotation = Map.createAnnotation({
+            const clusterAnnotation = Map.createAnnotation({
                 showAsMarker: true,
-                markerText: e.memberAnnotations.length.toString(),
+                markerText: event.memberAnnotations.length.toString(),
                 title: 'Cluster Title',
                 subtitle: 'Cluster Subtitle',
             });
 
-            mapview.setClusterAnnotation({
+            mapView.setClusterAnnotation({
                 annotation: clusterAnnotation,
-                memberAnnotations: e.memberAnnotations
+                memberAnnotations: event.memberAnnotations
             });
         });
-        win.add(mapview);
-        win.open();
+        window.add(mapView);
+        window.open();
+        ```
+  - title: Search Request (iOS only)
+    example: |
+        The following example shows the MapKit based search request:
+        
+        ```javascript
+        import Map from 'ti.map';
+
+        Map.addEventListener('didUpdateResults', event => {
+            console.warn('Found place:');
+            console.warn(event)
+        });
+
+        Map.search('Colloseum Rome');
         ```
 
 ---
@@ -709,7 +765,27 @@ properties:
   - name: longitude
     summary: Longitude value of the map point, in decimal degrees.
     type: Number
-
   - name: latitude
     summary: Latitude value of the map point, in decimal degrees.
+    type: Number
+
+---
+name: SearchCompletionOptions
+summary: Additional options to fine-tune the search request.
+description: The latitute and longitude describe the location, the delta values the distance to include.
+properties:
+  - name: latitude
+    summary: Latitude value of the search request, in decimal degrees.
+    type: Number
+  - name: longitude
+    summary: Longitude value of the search request, in decimal degrees.
+    type: Number
+  - name: latitude
+    summary: Latitude value of the search request, in decimal degrees.
+    type: Number
+  - name: latitudeDelta
+    summary: The amount of north-to-south distance displayed on the map, measured in decimal degrees.
+    type: Number
+  - name: longitudeDelta
+    summary: The amount of east-to-west distance displayed on the map, measured in decimal degrees.
     type: Number

--- a/apidoc/Map.yml
+++ b/apidoc/Map.yml
@@ -484,6 +484,27 @@ properties:
     osver: {ios: {min: "11.0"} }
     exclude-platforms: [android]
     since: "6.3.0"
+  
+  - name: SEARCH_RESULT_TYPE_ADDRESS
+    summary: A value that indicates that search results include addresses.
+    type: Number
+    permission: read-only
+    osver: {ios: {min: "13.0"} }
+    since: "12.3.0"
+ 
+  - name: SEARCH_RESULT_TYPE_POINT_OF_INTEREST
+    summary: A value that indicates that search results include points of interest.
+    type: Number
+    permission: read-only
+    osver: {ios: {min: "13.0"} }
+    since: "12.3.0"
+
+  - name: SEARCH_RESULT_TYPE_QUERY
+    summary: A value that indicates that the search completer includes query completions in results.
+    type: Number
+    permission: read-only
+    osver: {ios: {min: "13.0"} }
+    since: "12.3.0"
 
 methods:
   - name: isGooglePlayServicesAvailable
@@ -789,3 +810,11 @@ properties:
   - name: longitudeDelta
     summary: The amount of east-to-west distance displayed on the map, measured in decimal degrees.
     type: Number
+  - name: resultTypes
+    summary: These options configure the types of search results you want to receive, including points of interest and addresses.
+    description: |
+        Use one or more of the following constants:
+          - <Modules.Map.SEARCH_RESULT_TYPE_ADDRESS>
+          - <Modules.Map.SEARCH_RESULT_TYPE_POINT_OF_INTEREST>
+          - <Modules.Map.SEARCH_RESULT_TYPE_QUERY>
+    type: Array<Number>

--- a/apidoc/Map.yml
+++ b/apidoc/Map.yml
@@ -766,7 +766,9 @@ examples:
         ```
   - title: Search Request (iOS only)
     example: |
-        The following example shows the MapKit based search request:
+        The following example shows the MapKit based search request.
+        The options in `search` (2nd parameter) are optional, but improve
+        the accuracy of the results.
         
         ```javascript
         import Map from 'ti.map';
@@ -776,7 +778,15 @@ examples:
             console.warn(event)
         });
 
-        Map.search('Colloseum Rome');
+        Map.search('Colosseum', {
+          region: {
+            latitude: 41.890560,
+            longitude: 12.494270,
+            latitudeDelta: 1,
+            longitudeDelta: 1,
+          },
+          resultTypes: [Map.SEARCH_RESULT_TYPE_POINT_OF_INTEREST, Map.SEARCH_RESULT_TYPE_ADDRESS]
+        });
         ```
 
 ---
@@ -795,21 +805,11 @@ name: SearchCompletionOptions
 summary: Additional options to fine-tune the search request.
 description: The latitute and longitude describe the location, the delta values the distance to include.
 properties:
-  - name: latitude
-    summary: Latitude value of the search request, in decimal degrees.
-    type: Number
-  - name: longitude
-    summary: Longitude value of the search request, in decimal degrees.
-    type: Number
-  - name: latitude
-    summary: Latitude value of the search request, in decimal degrees.
-    type: Number
-  - name: latitudeDelta
-    summary: The amount of north-to-south distance displayed on the map, measured in decimal degrees.
-    type: Number
-  - name: longitudeDelta
-    summary: The amount of east-to-west distance displayed on the map, measured in decimal degrees.
-    type: Number
+  - name: region
+    summary: |
+        The region to look for results. Note that only `latitude`, `longitude`, `latitudeDelta` and `longitudeDelta`
+        are currently handled to define the region.
+    type: MapRegionTypev2
   - name: resultTypes
     summary: These options configure the types of search results you want to receive, including points of interest and addresses.
     description: |

--- a/ios/Classes/TiMapModule.h
+++ b/ios/Classes/TiMapModule.h
@@ -9,11 +9,12 @@
 #import <TitaniumKit/TiModule.h>
 
 #if IS_SDK_IOS_16
-@interface TiMapModule : TiModule <MKLookAroundViewControllerDelegate> {
+@interface TiMapModule : TiModule <MKLookAroundViewControllerDelegate, MKLocalSearchCompleterDelegate> {
 #else
 @interface TiMapModule : TiModule {
 #endif
   UIColor *colorRed;
+  MKLocalSearchCompleter *_searchCompleter;
 }
 
 @property (nonatomic, readonly) NSNumber *STANDARD_TYPE;

--- a/ios/Classes/TiMapModule.m
+++ b/ios/Classes/TiMapModule.m
@@ -147,9 +147,10 @@
     }
 
     // Handle search region
-    if (options[@"latitude"] && options[@"longitude"] && options[@"latitudeDelta"] && options[@"longitudeDelta"]) {
-      CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake([TiUtils doubleValue:options[@"latitude"]], [TiUtils doubleValue:options[@"longitude"]]);
-      MKCoordinateSpan span = MKCoordinateSpanMake([TiUtils doubleValue:options[@"latitudeDelta"]], [TiUtils doubleValue:options[@"longitudeDelta"]]);
+    if (options[@"region"]) {
+      NSDictionary<NSString *, NSNumber *> *region = options[@"region"];
+      CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake([TiUtils doubleValue:region[@"latitude"]], [TiUtils doubleValue:region[@"longitude"]]);
+      MKCoordinateSpan span = MKCoordinateSpanMake([TiUtils doubleValue:region[@"latitudeDelta"]], [TiUtils doubleValue:region[@"longitudeDelta"]]);
 
       if (CLLocationCoordinate2DIsValid(coordinate)) {
         [[self searchCompleter] setRegion:MKCoordinateRegionMake(coordinate, span)];

--- a/ios/Classes/TiMapModuleAssets.m
+++ b/ios/Classes/TiMapModuleAssets.m
@@ -3,18 +3,20 @@
  */
 #import "TiMapModuleAssets.h"
 
-extern NSData *filterDataInRange(NSData *thedata, NSRange range);
+extern NSData* filterDataInRange(NSData* thedata, NSRange range);
 
 @implementation TiMapModuleAssets
 
 - (NSData *)moduleAsset
 {
+  
 
   return nil;
 }
 
 - (NSData *)resolveModuleAsset:(NSString *)path
 {
+  
 
   return nil;
 }

--- a/ios/Classes/TiMapModuleAssets.m
+++ b/ios/Classes/TiMapModuleAssets.m
@@ -3,20 +3,18 @@
  */
 #import "TiMapModuleAssets.h"
 
-extern NSData* filterDataInRange(NSData* thedata, NSRange range);
+extern NSData *filterDataInRange(NSData *thedata, NSRange range);
 
 @implementation TiMapModuleAssets
 
 - (NSData *)moduleAsset
 {
-  
 
   return nil;
 }
 
 - (NSData *)resolveModuleAsset:(NSString *)path
 {
-  
 
   return nil;
 }

--- a/ios/Classes/TiMapUtils.h
+++ b/ios/Classes/TiMapUtils.h
@@ -7,11 +7,14 @@
 
 #import <CoreLocation/CoreLocation.h>
 #import <Foundation/Foundation.h>
+#import <MapKit/MapKit.h>
 
 @interface TiMapUtils : NSObject
 
 + (id)returnValueOnMainThread:(id (^)(void))block;
 
 + (NSDictionary<NSString *, id> *)dictionaryFromPlacemark:(CLPlacemark *)placemark;
+
++ (MKLocalSearchCompleterResultType)mappedResultTypes:(NSArray<NSNumber *> *)inputResultTypes;
 
 @end

--- a/ios/Classes/TiMapUtils.m
+++ b/ios/Classes/TiMapUtils.m
@@ -56,4 +56,16 @@
   return place;
 }
 
++ (MKLocalSearchCompleterResultType)mappedResultTypes:(NSArray<NSNumber *> *)inputResultTypes
+{
+  MKLocalSearchCompleterResultType resultTypes = 0;
+
+  for (NSNumber *number in inputResultTypes) {
+    MKLocalSearchCompleterResultType typeValue = [number unsignedIntegerValue];
+    resultTypes |= typeValue;
+  }
+
+  return resultTypes;
+}
+
 @end

--- a/ios/Classes/TiMapViewProxy.h
+++ b/ios/Classes/TiMapViewProxy.h
@@ -65,7 +65,6 @@
 - (void)removeImageOverlay:(id)arg;
 - (void)removeAllImageOverlays:(id)args;
 - (void)setClusterAnnotation:(id)args;
-- (void)setLocation:(id)location;
 - (NSNumber *)containsCoordinate:(id)args;
 
 @end

--- a/ios/manifest
+++ b/ios/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 
-version: 7.2.0
+version: 7.3.0
 apiversion: 2
 architectures: arm64 x86_64
 description: External version of Map module

--- a/ios/map.xcodeproj/project.pbxproj
+++ b/ios/map.xcodeproj/project.pbxproj
@@ -183,6 +183,8 @@
 				DB3656EF1E50BA740040E0B9 /* TiMapConstants.h */,
 				24DD6CF71134B3F500162E58 /* TiMapModule.h */,
 				24DD6CF81134B3F500162E58 /* TiMapModule.m */,
+				CEE33CF119EC4C150005E745 /* TiMapUtils.h */,
+				CEE33CF219EC4C150005E745 /* TiMapUtils.m */,
 				24DE9E0F11C5FE74003F90F6 /* TiMapModuleAssets.h */,
 				24DE9E1011C5FE74003F90F6 /* TiMapModuleAssets.m */,
 			);
@@ -293,8 +295,6 @@
 				CED651C317D7AA21007C2954 /* TiMapView.m */,
 				CED651C417D7AA21007C2954 /* TiMapViewProxy.h */,
 				CED651C517D7AA21007C2954 /* TiMapViewProxy.m */,
-				CEE33CF119EC4C150005E745 /* TiMapUtils.h */,
-				CEE33CF219EC4C150005E745 /* TiMapUtils.m */,
 				27A609E819F5922B00CA150A /* WildcardGestureRecognizer.h */,
 				27A609E919F5927000CA150A /* WildcardGestureRecognizer.m */,
 			);


### PR DESCRIPTION
See the new api docs for details!

Full example:
```js
import Map from 'ti.map';

const window = Ti.UI.createWindow();

const mapView = Map.createView({
  mapType: Map.NORMAL_TYPE
});

window.add(mapView);

Map.addEventListener('didUpdateResults', event => {
  console.warn('Found place:');
  console.warn(event)
});
setTimeout(function() {
  Map.search('Colosseum', {
    // Optional: Define search region
    region: {
      latitude: 41.890560,
      longitude: 12.494270,
      latitudeDelta: 1,
      longitudeDelta: 1,
    },
    // Optional: Define result types (POIs and/or address)
    resultTypes: [Map.SEARCH_RESULT_TYPE_POINT_OF_INTEREST, Map.SEARCH_RESULT_TYPE_ADDRESS]
  });
}, 2000)
window.open();
```

Download: [ti.map-iphone-7.3.0.zip](https://github.com/tidev/ti.map/files/12706539/ti.map-iphone-7.3.0.zip)