### PR TITLE
fix(android): nonNull getPosition

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.6.0
+version: 5.6.2
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: External version of Map module using native Google Maps library

--- a/android/src/ti/map/TiClusterRenderer.java
+++ b/android/src/ti/map/TiClusterRenderer.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.view.View;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
+import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.maps.android.clustering.ClusterManager;
@@ -111,7 +112,7 @@ public class TiClusterRenderer extends DefaultClusterRenderer<TiMarker>
 		}
 		// Update marker position if the item changed position
 		if (!marker.getPosition().equals(item.getPosition())) {
-			if (item.getPosition() != null) {
+			if (!item.getPosition().equals(new LatLng(0, 0))) {
 				marker.setPosition(item.getPosition());
 			}
 			changed = true;

--- a/android/src/ti/map/TiMarker.java
+++ b/android/src/ti/map/TiMarker.java
@@ -7,6 +7,7 @@
 
 package ti.map;
 
+import androidx.annotation.NonNull;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
 import com.google.maps.android.clustering.ClusterItem;
@@ -48,13 +49,14 @@ public class TiMarker implements ClusterItem
 		}
 	}
 
+	@NonNull
 	@Override
 	public LatLng getPosition()
 	{
 		if (proxy != null) {
 			return proxy.getMarkerOptions().getPosition();
 		}
-		return null;
+		return new LatLng(0, 0);
 	}
 
 	@Override

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -501,7 +501,9 @@ public class TiUIMapView extends TiUIFragment
 
 		LatLngBounds.Builder builder = new LatLngBounds.Builder();
 		for (TiMarker marker : markers) {
-			builder.include(marker.getPosition());
+			if (!marker.getPosition().equals(new LatLng(0, 0))) {
+				builder.include(marker.getPosition());
+			}
 		}
 		LatLngBounds bounds = builder.build();
 
@@ -645,7 +647,7 @@ public class TiUIMapView extends TiUIFragment
 				// It is assigned to the TiMarker instance after it has been rendered in
 				// onClusterItemRendered callback.
 				tiMarker = new TiMarker(null, annotation);
-				if (mClusterManager != null) {
+				if (mClusterManager != null && tiMarker != null) {
 					mClusterManager.addItem((TiMarker) tiMarker);
 					mClusterManager.cluster();
 				}


### PR DESCRIPTION
I was searching the code what could cause this error
```
java.lang.NullPointerException: Attempt to invoke virtual method 'int com.google.android.gms.maps.model.LatLng.hashCode()' on a null object reference
       at com.google.maps.android.clustering.algo.StaticCluster.hashCode(StaticCluster.java:71)
       at java.util.HashMap.hash(HashMap.java:336)
       at java.util.HashMap.put(HashMap.java:608)
       at java.util.HashSet.add(HashSet.java:220)
       at com.google.maps.android.clustering.algo.NonHierarchicalDistanceBasedAlgorithm.getClusters(NonHierarchicalDistanceBasedAlgorithm.java:201)
       at com.google.maps.android.clustering.algo.PreCachingAlgorithmDecorator.getClustersInternal(PreCachingAlgorithmDecorator.java:141)
       at com.google.maps.android.clustering.algo.PreCachingAlgorithmDecorator.access$000(PreCachingAlgorithmDecorator.java:34)
       at com.google.maps.android.clustering.algo.PreCachingAlgorithmDecorator$PrecacheRunnable.run(PreCachingAlgorithmDecorator.java:164)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
       at java.lang.Thread.run(Thread.java:1012)
```

and I found one place in our ClusterRenderer in `getPositiom()` that could return `null` for a cluster. BUT with Android Studio I saw that it actually is marked as `@NonNull`. So I've added that in our override and in rare cases where it was returning `null` before (when the `proxy` is gone already but it still tries to create a cluster) it now returns LatLng(0,0). From my understanding that should only be the case when you e.g. close a window and it is clustering items and they are being removed.

Also added another null check for `tiMarker` before adding a cluster item.

I've tested it with annotations at position 0,0 and they are displayed and also clustered. So in a rare case when you want to add something at 0,0 it still is displayed :smile: 

I couldn't verify if this fixes that error because it happens very very rarely. But using this for a couple of days now and no crash so far :crossed_fingers: 

[ti.map-android-5.6.2.zip](https://github.com/tidev/ti.map/files/12838027/ti.map-android-5.6.2.zip)
