### PR TITLE
fix(ios): make left/rightButton/View fire events again

### DIFF
--- a/ios/Classes/TiMapView.m
+++ b/ios/Classes/TiMapView.m
@@ -1277,13 +1277,16 @@ CLLocationCoordinate2D userNewLocation;
   UIView *right = [ann rightViewAccessory];
 
   [annView setHidden:[TiUtils boolValue:[ann valueForUndefinedKey:@"hidden"] def:NO]];
-
   if (left != nil) {
     annView.leftCalloutAccessoryView = left;
+    UITapGestureRecognizer *singleFingerTapLeft = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSingleTapLeft:)];
+    [left addGestureRecognizer:singleFingerTapLeft];
   }
 
   if (right != nil) {
     annView.rightCalloutAccessoryView = right;
+    UITapGestureRecognizer *singleFingerTapRight = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSingleTapRight:)];
+    [right addGestureRecognizer:singleFingerTapRight];
   }
 
   [annView setDraggable:[TiUtils boolValue:[ann valueForUndefinedKey:@"draggable"]]];
@@ -1313,6 +1316,17 @@ CLLocationCoordinate2D userNewLocation;
   }
   return annView;
 }
+
+- (void)handleSingleTapLeft:(UITapGestureRecognizer *)recognizer
+{
+  [self fireClickEvent:selectedAnnotation source:@"leftButton" deselected:NO];
+}
+
+- (void)handleSingleTapRight:(UITapGestureRecognizer *)recognizer
+{
+  [self fireClickEvent:selectedAnnotation source:@"rightButton" deselected:NO];
+}
+
 - (void)animateAnnotation:(TiMapAnnotationProxy *)newAnnotation withLocation:(CLLocationCoordinate2D)newLocation
 {
   userNewLocation.latitude = newLocation.latitude;

--- a/ios/manifest
+++ b/ios/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 
-version: 7.3.1
+version: 7.3.2
 apiversion: 2
 architectures: arm64 x86_64
 description: External version of Map module


### PR DESCRIPTION
:warning: not sure if the code is the best. But the test app worked. Feel free to adjust or test it :warning: 

Adds a `fireevent` to the leftButton/leftView or rightButton/rightView again.

**Test**

```js
var Map = require('ti.map');
var win = Titanium.UI.createWindow();

var mountainView = Map.createAnnotation({
	latitude: 37.390749,
	longitude: -122.081651,
	title: 'Appcelerator Headquarters',
	subtitle: 'Mountain View, CA',
	leftButton: Ti.UI.iOS.SystemButton.INFO_LIGHT,
	rightView: Ti.UI.createView({width: 50,height: 50, backgroundColor:"red"}),
});
var lbl = Ti.UI.createLabel({bottom: 20, text: "-", backgroundColor: "#fff"});

var mapview = Map.createView({
	mapType: Map.NORMAL_TYPE,
	region: {
		latitude: 37.390749,
		longitude: -122.081651,
		latitudeDelta: 0.01,
		longitudeDelta: 0.01
	},
	animate: true,
	regionFit: true,
	userLocation: true,
	annotations: [mountainView]
});

win.add(mapview);
win.add(lbl);

var clickCounter = 0;
mapview.addEventListener('click', function(event) {
	console.log(lbl.text = clickCounter + ': clicked ' + event.clicksource);
	lbl.text = clickCounter + ': clicked ' + event.clicksource + " - " + event.title;
	clickCounter++;
});
win.open();
```

click on the left button or right view inside the annotation and look at the log/label at the bottom.

[ti.map-iphone-7.3.2.zip](https://github.com/tidev/ti.map/files/13060525/ti.map-iphone-7.3.2.zip)


https://github.com/tidev/ti.map/assets/4334997/6d70c651-82a8-49a8-b743-39cf307c0509


