### PR TITLE
chore(android): version bump

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.6.0
+version: 5.6.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: External version of Map module using native Google Maps library


### PR DESCRIPTION
just a version bump as it looks like the Release ZIP is not the master branch. The `toColor()` fix is not included there

[ti.map-android-5.6.1.zip](https://github.com/tidev/ti.map/files/13962810/ti.map-android-5.6.1.zip)

I'll create a PR for the Ti SDK once it is merged