### PR TITLE
feat(ios): add cutout circle API

### DIFF
--- a/apidoc/Map.yml
+++ b/apidoc/Map.yml
@@ -818,3 +818,31 @@ properties:
           - <Modules.Map.SEARCH_RESULT_TYPE_POINT_OF_INTEREST>
           - <Modules.Map.SEARCH_RESULT_TYPE_QUERY>
     type: Array<Number>
+
+---
+name: CutoutCircleConfiguration
+summary: Options to configure a cutout circle (iOS only right now).
+properties:
+  - name: longitude
+    summary: Longitude value of the map point, in decimal degrees.
+    type: Number
+  - name: latitude
+    summary: Latitude value of the map point, in decimal degrees.
+    type: Number
+  - name: radius
+    summary: The radius of the circle in meters.
+    type: Number
+  - name: overlayColor
+    summary: The color of the overlay (not the circle).
+    type: String
+  - name: strokeColor
+    summary: |
+        Color to use for the the polyline, as a color name or hex triplet.
+    description: |
+        For information about color values, see the "Colors" section of <Titanium.UI>.
+    type: String
+    default: black
+  - name: strokeWidth
+    summary: Line width in pixels to use when drawing the polyline.
+    type: Number
+    default: 10

--- a/apidoc/View.yml
+++ b/apidoc/View.yml
@@ -280,6 +280,19 @@ methods:
   - name: removeAllPolylines
     summary: Remove all polylines from the map.
 
+  - name: addCutoutCircle
+    summary: Adds a new cutout circle to the map.
+    description: |
+        A cutout circle represents a special polygon that spans over the
+        whole world and has a cutout in the shape of a circle. The radius
+        of the shape, the overlay color and stroke properties can be configured.
+    exclude-platforms: [android]
+    since: { iphone: "7.4.0", ipad: "7.4.0", macos: "7.4.0" }
+    parameters:
+      - name: circleConfiguration
+        summary: A <Modules.Map.CutoutCircleConfiguration> object.
+        type: Modules.Map.CutoutCircleConfiguration
+
   - name: addCircle
     summary: Adds a new circle to the map.
     parameters:

--- a/ios/Classes/TiCutoutCircle.h
+++ b/ios/Classes/TiCutoutCircle.h
@@ -1,0 +1,12 @@
+//
+//  TiCutoutCircle.h
+//  map
+//
+//  Created by Hans Knöchel on 30.01.24.
+//
+
+#import <MapKit/MapKit.h>
+
+@interface TiCutoutCircle : MKPolygon
+
+@end

--- a/ios/Classes/TiCutoutCircle.m
+++ b/ios/Classes/TiCutoutCircle.m
@@ -1,0 +1,12 @@
+//
+//  TiCutoutCircle.m
+//  map
+//
+//  Created by Hans Knöchel on 30.01.24.
+//
+
+#import "TiCutoutCircle.h"
+
+@implementation TiCutoutCircle
+
+@end

--- a/ios/Classes/TiMapPolygonProxy.m
+++ b/ios/Classes/TiMapPolygonProxy.m
@@ -6,6 +6,7 @@
  */
 
 #import "TiMapPolygonProxy.h"
+#import "TiMapUtils.h"
 
 @implementation TiMapPolygonProxy
 
@@ -46,7 +47,7 @@
 
   for (int i = 0; i < [points count]; i++) {
     id locObj = [points objectAtIndex:i];
-    CLLocationCoordinate2D coord = [self processLocation:locObj];
+    CLLocationCoordinate2D coord = [TiMapUtils processLocation:locObj];
     coordArray[i] = coord;
   }
 
@@ -61,7 +62,7 @@
 
       for (int j = 0; j < [holeObj count]; ++j) {
         id obj = [holeObj objectAtIndex:j];
-        CLLocationCoordinate2D coord = [self processLocation:obj];
+        CLLocationCoordinate2D coord = [TiMapUtils processLocation:obj];
         hole[j] = coord;
       }
 
@@ -81,27 +82,6 @@
   [self applyFillColor];
   [self applyStrokeColor];
   [self applyStrokeWidth];
-}
-
-// A location can either be a an array of longitude, latitude pairings or
-// an array of longitude, latitude objects.
-// e.g. [ [123.33, 34.44], [100.39, 78.23], etc. ]
-// [ {longitude: 123.33, latitude, 34.44}, {longitude: 100.39, latitude: 78.23}, etc. ]
-- (CLLocationCoordinate2D)processLocation:(id)locObj
-{
-  if ([locObj isKindOfClass:[NSDictionary class]]) {
-    CLLocationDegrees lat = [TiUtils doubleValue:[locObj objectForKey:@"latitude"]];
-    CLLocationDegrees lon = [TiUtils doubleValue:[locObj objectForKey:@"longitude"]];
-
-    return CLLocationCoordinate2DMake(lat, lon);
-  } else if ([locObj isKindOfClass:[NSArray class]]) {
-    CLLocationDegrees lat = [TiUtils doubleValue:[locObj objectAtIndex:1]];
-    CLLocationDegrees lon = [TiUtils doubleValue:[locObj objectAtIndex:0]];
-
-    return CLLocationCoordinate2DMake(lat, lon);
-  }
-
-  return kCLLocationCoordinate2DInvalid;
 }
 
 - (void)applyFillColor

--- a/ios/Classes/TiMapPolylineProxy.m
+++ b/ios/Classes/TiMapPolylineProxy.m
@@ -7,6 +7,7 @@
 
 #import "TiMapPolylineProxy.h"
 #import "TiMapConstants.h"
+#import "TiMapUtils.h"
 
 @implementation TiMapPolylineProxy
 
@@ -45,7 +46,7 @@
 
   for (int i = 0; i < [points count]; i++) {
     id locObj = [points objectAtIndex:i];
-    CLLocationCoordinate2D coord = [self processLocation:locObj];
+    CLLocationCoordinate2D coord = [TiMapUtils processLocation:locObj];
     coordArray[i] = coord;
   }
 
@@ -56,27 +57,6 @@
   [self applyStrokeColor];
   [self applyStrokeWidth];
   [self applyStrokePattern];
-}
-
-// A location can either be a an array of longitude, latitude pairings or
-// an array of longitude, latitude objects.
-// e.g. [ [123.33, 34.44], [100.39, 78.23], etc. ]
-// [ {longitude: 123.33, latitude, 34.44}, {longitude: 100.39, latitude: 78.23}, etc. ]
-- (CLLocationCoordinate2D)processLocation:(id)locObj
-{
-  if ([locObj isKindOfClass:[NSDictionary class]]) {
-    CLLocationDegrees lat = [TiUtils doubleValue:[locObj objectForKey:@"latitude"]];
-    CLLocationDegrees lon = [TiUtils doubleValue:[locObj objectForKey:@"longitude"]];
-
-    return CLLocationCoordinate2DMake(lat, lon);
-  } else if ([locObj isKindOfClass:[NSArray class]]) {
-    CLLocationDegrees lat = [TiUtils doubleValue:[locObj objectAtIndex:1]];
-    CLLocationDegrees lon = [TiUtils doubleValue:[locObj objectAtIndex:0]];
-
-    return CLLocationCoordinate2DMake(lat, lon);
-  }
-
-  return kCLLocationCoordinate2DInvalid;
 }
 
 - (void)applyStrokeColor

--- a/ios/Classes/TiMapUtils.h
+++ b/ios/Classes/TiMapUtils.h
@@ -17,4 +17,8 @@
 
 + (MKLocalSearchCompleterResultType)mappedResultTypes:(NSArray<NSNumber *> *)inputResultTypes;
 
++ (NSArray<NSDictionary *> *)makeCircleCoordinates:(CLLocationCoordinate2D)coordinate withRadius:(double)radius andTolerance:(double)tolerance;
+
++ (CLLocationCoordinate2D)processLocation:(id)locObj;
+
 @end

--- a/ios/Classes/TiMapUtils.m
+++ b/ios/Classes/TiMapUtils.m
@@ -68,4 +68,47 @@
   return resultTypes;
 }
 
++ (NSArray<NSDictionary *> *)makeCircleCoordinates:(CLLocationCoordinate2D)coordinate withRadius:(double)radius andTolerance:(double)tolerance
+{
+  NSMutableArray<NSDictionary *> *coordinates = [[NSMutableArray alloc] init];
+  double latRadian = coordinate.latitude * M_PI / 180.0;
+  double lngRadian = coordinate.longitude * M_PI / 180.0;
+  double distance = (radius / 1000.0) / 6371.0; // kms
+
+  for (double angle = 0; angle < 360.0; angle += tolerance) {
+    double bearing = angle * M_PI / 180.0;
+
+    double lat2 = asin(sin(latRadian) * cos(distance) + cos(latRadian) * sin(distance) * cos(bearing));
+    double lon2 = lngRadian + atan2(sin(bearing) * sin(distance) * cos(latRadian), cos(distance) - sin(latRadian) * sin(lat2));
+    lon2 = fmod(lon2 + 3 * M_PI, 2 * M_PI) - M_PI; // normalize to -180..+180º
+
+    NSNumber *latitude = @(lat2 * (180.0 / M_PI));
+    NSNumber *longitude = @(lon2 * (180.0 / M_PI));
+    [coordinates addObject:@{ @"latitude" : latitude, @"longitude" : longitude }];
+  }
+
+  return coordinates;
+}
+
+// A location can either be a an array of longitude, latitude pairings or
+// an array of longitude, latitude objects.
+// e.g. [ [123.33, 34.44], [100.39, 78.23], etc. ]
+// [ {longitude: 123.33, latitude, 34.44}, {longitude: 100.39, latitude: 78.23}, etc. ]
++ (CLLocationCoordinate2D)processLocation:(id)locObj
+{
+  if ([locObj isKindOfClass:[NSDictionary class]]) {
+    CLLocationDegrees lat = [TiUtils doubleValue:[locObj objectForKey:@"latitude"]];
+    CLLocationDegrees lon = [TiUtils doubleValue:[locObj objectForKey:@"longitude"]];
+
+    return CLLocationCoordinate2DMake(lat, lon);
+  } else if ([locObj isKindOfClass:[NSArray class]]) {
+    CLLocationDegrees lat = [TiUtils doubleValue:[locObj objectAtIndex:1]];
+    CLLocationDegrees lon = [TiUtils doubleValue:[locObj objectAtIndex:0]];
+
+    return CLLocationCoordinate2DMake(lat, lon);
+  }
+
+  return kCLLocationCoordinate2DInvalid;
+}
+
 @end

--- a/ios/Classes/TiMapView.m
+++ b/ios/Classes/TiMapView.m
@@ -6,6 +6,7 @@
  */
 
 #import "TiMapView.h"
+#import "TiCutoutCircle.h"
 #import "TiMapAnnotationProxy.h"
 #import "TiMapCircleProxy.h"
 #import "TiMapCustomAnnotationView.h"
@@ -977,7 +978,6 @@ CLLocationCoordinate2D userNewLocation;
 
 #pragma mark Delegates
 
-// Delegate for >= iOS 8
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status
 {
   if ((status == kCLAuthorizationStatusAuthorizedWhenInUse) || (status == kCLAuthorizationStatusAuthorizedAlways)) {
@@ -985,9 +985,22 @@ CLLocationCoordinate2D userNewLocation;
   }
 }
 
-// Delegate for >= iOS 7
 - (MKOverlayRenderer *)mapView:(MKMapView *)mapView rendererForOverlay:(id<MKOverlay>)overlay
 {
+  if ([overlay isKindOfClass:[TiCutoutCircle class]]) {
+    NSDictionary *circleConfiguration = [[self proxy] valueForKey:@"cutoutCircle"];
+    UIColor *overlayColor = [TiUtils colorValue:@"overlayColor" properties:circleConfiguration def:[TiColor colorNamed:@"black"]].color;
+    UIColor *strokeColor = [TiUtils colorValue:@"strokeColor" properties:circleConfiguration def:[TiColor colorNamed:@"black"]].color;
+    CGFloat lineWidth = [TiUtils floatValue:@"strokeWidth" properties:circleConfiguration def:1.0];
+
+    MKPolygonRenderer *renderer = [[MKPolygonRenderer alloc] initWithOverlay:overlay];
+    renderer.lineWidth = lineWidth;
+    renderer.strokeColor = strokeColor;
+    renderer.fillColor = overlayColor;
+
+    return renderer;
+  }
+
   return (MKOverlayRenderer *)CFDictionaryGetValue(mapObjects2View, overlay);
 }
 

--- a/ios/Classes/TiMapViewProxy.m
+++ b/ios/Classes/TiMapViewProxy.m
@@ -5,6 +5,7 @@
  * Please see the LICENSE included with this distribution for details.
  */
 #import "TiMapViewProxy.h"
+#import "TiCutoutCircle.h"
 #import "TiMapAnnotationProxy.h"
 #import "TiMapCircleProxy.h"
 #import "TiMapImageOverlayProxy.h"
@@ -289,6 +290,40 @@
       [self addAnnotation:annotation];
     }
   }
+}
+
+- (void)addCutoutCircle:(id)arg
+{
+  ENSURE_SINGLE_ARG(arg, NSDictionary);
+
+  [self replaceValue:arg forKey:@"cutoutCircle" notification:NO];
+
+  CGFloat latitude = [TiUtils floatValue:@"latitude" properties:arg];
+  CGFloat longitude = [TiUtils floatValue:@"longitude" properties:arg];
+  double radius = [TiUtils doubleValue:@"radius" properties:arg];
+  double tolerance = [TiUtils doubleValue:@"tolerance" properties:arg def:3.0];
+
+  CLLocationCoordinate2D WORLD_COORDINATES[6];
+  WORLD_COORDINATES[0] = CLLocationCoordinate2DMake(90, 0);
+  WORLD_COORDINATES[1] = CLLocationCoordinate2DMake(90, 180);
+  WORLD_COORDINATES[2] = CLLocationCoordinate2DMake(-90, 180);
+  WORLD_COORDINATES[3] = CLLocationCoordinate2DMake(-90, 0);
+  WORLD_COORDINATES[4] = CLLocationCoordinate2DMake(-90, -180);
+  WORLD_COORDINATES[5] = CLLocationCoordinate2DMake(90, -180);
+
+  CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake(latitude, longitude);
+  NSArray<NSDictionary *> *circleCoordinates = [TiMapUtils makeCircleCoordinates:coordinate withRadius:radius andTolerance:tolerance];
+  CLLocationCoordinate2D *circleCoordinatesNative = malloc(sizeof(CLLocationCoordinate2D) * [circleCoordinates count]);
+
+  for (int i = 0; i < [circleCoordinates count]; ++i) {
+    CLLocationCoordinate2D coordinate = [TiMapUtils processLocation:[circleCoordinates objectAtIndex:i]];
+    circleCoordinatesNative[i] = coordinate;
+  }
+
+  MKPolygon *polygon1 = [MKPolygon polygonWithCoordinates:circleCoordinatesNative count:circleCoordinates.count];
+  TiCutoutCircle *polygon2 = [TiCutoutCircle polygonWithCoordinates:WORLD_COORDINATES count:6 interiorPolygons:@[ polygon1 ]];
+
+  [[(TiMapView *)[self view] map] addOverlay:polygon2];
 }
 
 - (void)setAnnotations:(id)arg

--- a/ios/manifest
+++ b/ios/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 
-version: 7.3.1
+version: 7.4.0
 apiversion: 2
 architectures: arm64 x86_64
 description: External version of Map module

--- a/ios/map.xcodeproj/project.pbxproj
+++ b/ios/map.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		27A609F019F711B700CA150A /* TiMapPolylineProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A609EF19F711B700CA150A /* TiMapPolylineProxy.m */; };
 		3A155BE82A9B35C000247646 /* TiMapFeatureAnnotationProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A155BE62A9B35C000247646 /* TiMapFeatureAnnotationProxy.h */; };
 		3A155BE92A9B35C000247646 /* TiMapFeatureAnnotationProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A155BE72A9B35C000247646 /* TiMapFeatureAnnotationProxy.m */; };
+		3A699AC92B68CB0E00938935 /* TiCutoutCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A699AC72B68CB0E00938935 /* TiCutoutCircle.h */; };
+		3A699ACA2B68CB0E00938935 /* TiCutoutCircle.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A699AC82B68CB0E00938935 /* TiCutoutCircle.m */; };
 		815136F31D355BF5009E3E2C /* TiMapSnapshotterProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 815136F11D355BF5009E3E2C /* TiMapSnapshotterProxy.h */; };
 		815136F41D355BF5009E3E2C /* TiMapSnapshotterProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 815136F21D355BF5009E3E2C /* TiMapSnapshotterProxy.m */; };
 		AA747D9F0F9514B9006C5449 /* TiMap_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = AA747D9E0F9514B9006C5449 /* TiMap_Prefix.pch */; };
@@ -98,6 +100,8 @@
 		27A609EF19F711B700CA150A /* TiMapPolylineProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TiMapPolylineProxy.m; path = Classes/TiMapPolylineProxy.m; sourceTree = "<group>"; };
 		3A155BE62A9B35C000247646 /* TiMapFeatureAnnotationProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TiMapFeatureAnnotationProxy.h; path = Classes/TiMapFeatureAnnotationProxy.h; sourceTree = "<group>"; };
 		3A155BE72A9B35C000247646 /* TiMapFeatureAnnotationProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = TiMapFeatureAnnotationProxy.m; path = Classes/TiMapFeatureAnnotationProxy.m; sourceTree = "<group>"; };
+		3A699AC72B68CB0E00938935 /* TiCutoutCircle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TiCutoutCircle.h; path = Classes/TiCutoutCircle.h; sourceTree = "<group>"; };
+		3A699AC82B68CB0E00938935 /* TiCutoutCircle.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = TiCutoutCircle.m; path = Classes/TiCutoutCircle.m; sourceTree = "<group>"; };
 		815136F11D355BF5009E3E2C /* TiMapSnapshotterProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TiMapSnapshotterProxy.h; path = Classes/TiMapSnapshotterProxy.h; sourceTree = "<group>"; };
 		815136F21D355BF5009E3E2C /* TiMapSnapshotterProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TiMapSnapshotterProxy.m; path = Classes/TiMapSnapshotterProxy.m; sourceTree = "<group>"; };
 		AA747D9E0F9514B9006C5449 /* TiMap_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiMap_Prefix.pch; sourceTree = SOURCE_ROOT; };
@@ -265,6 +269,8 @@
 				DB0CCA022010841A00597F24 /* Pattern */,
 				DB07496B1E081A36009D8A71 /* Polygon */,
 				DB07496A1E081A23009D8A71 /* Polyline */,
+				3A699AC72B68CB0E00938935 /* TiCutoutCircle.h */,
+				3A699AC82B68CB0E00938935 /* TiCutoutCircle.m */,
 			);
 			name = Overlays;
 			sourceTree = "<group>";
@@ -336,6 +342,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				194D001C2047DB4A002150BD /* TiMapImageOverlayProxy.h in Headers */,
+				3A699AC92B68CB0E00938935 /* TiCutoutCircle.h in Headers */,
 				AA747D9F0F9514B9006C5449 /* TiMap_Prefix.pch in Headers */,
 				CE92EC2217DF8B020082E943 /* TiMKOverlayPathUniversal.h in Headers */,
 				24DD6CF91134B3F500162E58 /* TiMapModule.h in Headers */,
@@ -430,6 +437,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3A699ACA2B68CB0E00938935 /* TiCutoutCircle.m in Sources */,
 				194D00212047DDED002150BD /* TiMapImageOverlayRenderer.m in Sources */,
 				24DD6CFA1134B3F500162E58 /* TiMapModule.m in Sources */,
 				194D001D2047DB4A002150BD /* TiMapImageOverlayProxy.m in Sources */,


### PR DESCRIPTION
This PR add a cutout circle API that represents a special polygon that spans over the whole world and has a cutout in the shape of a circle. The radius of the shape, the overlay color and stroke properties can be configured.

![Simulator Screenshot - iPhone Xs - 2024-01-30 at 10 34 46](https://github.com/tidev/ti.map/assets/10667698/19eac50a-2891-4983-80f0-3c5805104c19)
